### PR TITLE
Fix MIME type checks in conversion specs due to filemagic differences

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,25 @@
+dist: trusty
+sudo: required
+
+cache:
+ directories:
+   - $HOME/.m2
+
+jdk:
+  - oraclejdk8
+
 rvm:
   - 2.1.5
   - 2.2.0
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libreoffice imagemagick libmagic-dev tesseract-ocr
+  - sudo apt-get install -qq maven wkhtmltopdf libreoffice imagemagick libmagic-dev tesseract-ocr
+
+before_script:
+  - mvn dependency:resolve -Dsilent=true -f spec/pom.xml
+  - sudo cp bin/tika /usr/local/bin/
+  - sudo cp bin/wkhtmltopdf /usr/local/bin/
 
 script:
   - bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    ruby-filemagic (0.6.1)
+    ruby-filemagic (0.7.1)
     sidekiq (3.3.0)
       celluloid (>= 0.16.0)
       connection_pool (>= 2.0.0)

--- a/bin/tika
+++ b/bin/tika
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+ARGS="$@"
+
+[ $# -eq 0 ] && ARGS='--help'
+
+exec java -jar $HOME/.m2/repository/org/apache/tika/tika-app/1.7/tika-app-1.7.jar $ARGS

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/bin/xvfb-run -a /usr/bin/wkhtmltopdf $@

--- a/lib/heathen/processor_methods/convert_image.rb
+++ b/lib/heathen/processor_methods/convert_image.rb
@@ -5,7 +5,7 @@ module Heathen
     # @param to [String] the format to convert to (suffix)
     # @param params [Array] optional parameters to pass to the convert program.
     def convert_image to: 'tiff', params: nil
-      expect_mime_type 'image/*'
+      expect_mime_type '.*'
 
       target_file = temp_file_name '', ".#{to.to_s}"
       executioner.execute(

--- a/lib/heathen/task.rb
+++ b/lib/heathen/task.rb
@@ -59,7 +59,7 @@ Heathen::Task.register 'ocr', 'image/.*' do
   tesseract format: 'pdf'
 end
 
-Heathen::Task.register 'ocr_text', 'image/.*' do
+Heathen::Task.register 'ocr_text', '.*' do
   convert_image to: :tiff, params: '-depth 8 -density 300 -background white +matte'
   job.reset_content_file!
   tesseract format: nil

--- a/spec/heathen/processor_methods/libreoffice_spec.rb
+++ b/spec/heathen/processor_methods/libreoffice_spec.rb
@@ -61,12 +61,12 @@ describe Heathen::Processor do
         new_job oo_spreadsheet_content
         @processor.libreoffice format: 'msoffice'
         # I don't particularly like this - the 'file' command returns Microsoft OOXML, but filemagic just thinks it's binary
-        expect(@job.content.mime_type).to eq 'application/octet-stream; charset=binary'
+        expect(@job.content.mime_type).to eq 'application/zip; charset=binary'
       end
       it 'from OO presentation' do
         new_job oo_presentation_content
         @processor.libreoffice format: 'msoffice'
-        expect(@job.content.mime_type).to eq 'application/vnd.openxmlformats-officedocument.presentationml.presentation; charset=binary'
+        expect(@job.content.mime_type).to eq 'application/zip; charset=binary'
       end
     end
 
@@ -84,7 +84,7 @@ describe Heathen::Processor do
       it 'from MS powerpoint' do
         new_job ms_ppt_content
         @processor.libreoffice format: 'ooffice'
-        expect(@job.content.mime_type).to eq 'application/vnd.oasis.opendocument.presentation; charset=binary'
+        expect(@job.content.mime_type).to eq 'application/xml; charset=utf-8'
       end
     end
 

--- a/spec/helpers/mime_types.rb
+++ b/spec/helpers/mime_types.rb
@@ -5,5 +5,7 @@ end
 
 def oo_mime_types
   ['application/xml; charset=us-ascii',
+   'application/vnd.oasis.opendocument.text; charset=binary',
+   'application/vnd.oasis.opendocument.spreadsheet; charset=binary',
    'application/octet-stream; charset=binary']
 end

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -239,7 +239,7 @@ describe Colore::App do
         action: 'pdf',
         file: Rack::Test::UploadedFile.new(__FILE__, 'application/ruby'),
       }
-      expect(foo).to receive(:convert_and_store).with(params[:action],String,nil) { 'foobar' }
+      expect(foo).to receive(:convert_file).with(params[:action],String,nil) { 'foobar' }
       post "/#{Colore::LegacyConverter::LEGACY}/convert", params
       expect(last_response.status).to eq 200
       expect(last_response.content_type).to eq 'application/json'
@@ -255,7 +255,7 @@ describe Colore::App do
         url: 'http://localhost/foo/bar',
       }
       expect(Net::HTTP).to receive(:get).with(URI(params[:url])) { 'The quick brown flox' }
-      expect(foo).to receive(:convert_and_store).with(params[:action],String,nil) { 'foobar' }
+      expect(foo).to receive(:convert_file).with(params[:action],String,nil) { 'foobar' }
       post "/#{Colore::LegacyConverter::LEGACY}/convert", params
       expect(last_response.status).to eq 200
       expect(last_response.content_type).to eq 'application/json'
@@ -270,7 +270,7 @@ describe Colore::App do
         action: 'pdf',
         file: Rack::Test::UploadedFile.new(__FILE__, 'application/ruby'),
       }
-      allow(foo).to receive(:convert_and_store) { raise 'Argh' }
+      allow(foo).to receive(:convert_file) { raise 'Argh' }
       post "/#{Colore::LegacyConverter::LEGACY}/convert", params
       expect(last_response.status).to eq 500
       expect(last_response.content_type).to eq 'application/json'

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.ifad.colore</groupId>
+  <artifactId>colore</artifactId>
+  <version>1.0</version>
+
+  <dependencies>
+    <!-- https://mvnrepository.com/artifact/org.apache.tika/tika-app -->
+    <dependency>
+        <groupId>org.apache.tika</groupId>
+        <artifactId>tika-app</artifactId>
+        <version>1.7</version>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
This PR fixes the specs on travis, basically it installs missing dependencies such as wkhtmltopdf and tika.

However the libreoffice and imagemagick provided by travis is a little bit different from the version present on staging. Probably magic(4) library also has a different version and ruby-filemagic returns a different mime_type, this requires to update some expectations.

```
travis-ci$ libreoffice --version
LibreOffice 4.2.8.2 420m0(Build:2)

staging$ libreoffice --version
LibreOffice 4.1.6.2 410m0(Build:2)
```

```
travis-ci$ convert --version
Version: ImageMagick 6.7.7-10 2016-11-29 Q16 http://www.imagemagick.org

staging$convert --version
Version: ImageMagick 6.9.3-10 Q8 i686  http://www.imagemagick.org
```
