### PR TITLE
Fix raise_error warnings

### DIFF
--- a/spec/heathen/convert_spec.rb
+++ b/spec/heathen/convert_spec.rb
@@ -47,7 +47,7 @@ describe Heathen::Converter do
     end
     expect {
       described_class.new.convert 'test', 'test content'
-    }.to raise_error
+    }.to raise_error(RuntimeError, 'It failed')
   end
 
   it 'runs a nested task' do
@@ -69,7 +69,7 @@ describe Heathen::Converter do
     end
     expect {
       described_class.new.convert 'test_foo', 'test content'
-    }.to raise_error
+    }.to raise_error Heathen::TaskNotFound
   end
 
   it 'fails if the mime_type is not recognised' do
@@ -79,6 +79,6 @@ describe Heathen::Converter do
     end
     expect {
       described_class.new.convert 'test', 'test content'
-    }.to raise_error
+    }.to raise_error Heathen::TaskNotFound
   end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -25,7 +25,7 @@ describe Colore::C_ do
     it 'fails on invalid value' do
       expect {
         described_class.foo
-      }.to raise_error
+      }.to raise_error NoMethodError
     end
   end
 end


### PR DESCRIPTION
Using the `raise_error` matcher without providing a specific
error or message risks false positives, since `raise_error` will match
when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`,
potentially allowing the expectation to pass without even executing the
method you are intending to call.

This commits looks for a specific error to avoid false positives