### PR TITLE
Chore/fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,43 @@
+language: ruby
+
 rvm:
-  - 2.1.5
-  - 2.2.0
+  - 2.6.5
+
+services:
+  - redis-server
+
+addons:
+  apt:
+    update: true
+    packages:
+      - imagemagick
+      - libmagic-dev
+      - libreoffice
+      - tesseract-ocr
+
+cache:
+  bundler: true
 
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libreoffice imagemagick libmagic-dev tesseract-ocr
+  # tika
+  - wget --quiet https://apache.osuosl.org/tika/tika-app-1.24.jar
+  - mv tika-app-1.24.jar $HOME/bin/tika-app.jar
+  - echo $'#!/bin/sh\n\nARGS="$@"\n\n[ $# -eq 0 ] && ARGS="--help"\n\nexec java -jar $HOME/bin/tika-app.jar $ARGS\n' > $HOME/bin/tika
+  - cat $HOME/bin/tika
+  - chmod +x $HOME/bin/tika
+
+  # wkhtmltopdf (with qt)
+  - wget --quiet https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.xenial_amd64.deb
+  - dpkg -x wkhtmltox_0.12.5-1.xenial_amd64.deb tmp-wkhtmtopdf
+  - mv tmp-wkhtmtopdf/usr/local/bin/wkhtmltopdf $HOME/bin/wkhtmltopdf
+  - rm -rf wkhtmltox_0.12.5-1.xenial_amd64.deb tmp-wkhtmtopdf
+
+  # Show versions of all executables
+  - convert --version
+  - libreoffice --version
+  - tesseract --version
+  - tika --version
+  - wkhtmltopdf --version
 
 script:
   - bundle exec rspec

--- a/spec/heathen/processor_methods/libreoffice_spec.rb
+++ b/spec/heathen/processor_methods/libreoffice_spec.rb
@@ -60,7 +60,7 @@ describe Heathen::Processor do
       it 'from OO spreadsheet' do
         new_job oo_spreadsheet_content
         @processor.libreoffice format: 'msoffice'
-        expect(@job.content.mime_type).to eq 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; charset=binary'
+        expect(ms_excel_mime_types).to include(@job.content.mime_type)
       end
       it 'from OO presentation' do
         new_job oo_presentation_content
@@ -73,17 +73,17 @@ describe Heathen::Processor do
       it 'from MS word' do
         new_job ms_word_content
         @processor.libreoffice format: 'ooffice'
-        expect(oo_mime_types).to include(@job.content.mime_type)
+        expect(oo_odt_mime_types).to include(@job.content.mime_type)
       end
       it 'from MS spreadsheet' do
         new_job ms_spreadsheet_content
         @processor.libreoffice format: 'ooffice'
-        expect(oo_mime_types).to include(@job.content.mime_type)
+        expect(oo_ods_mime_types).to include(@job.content.mime_type)
       end
       it 'from MS powerpoint' do
         new_job ms_ppt_content
         @processor.libreoffice format: 'ooffice'
-        expect(@job.content.mime_type).to eq 'application/vnd.oasis.opendocument.presentation; charset=binary'
+        expect(oo_odp_mime_types).to include(@job.content.mime_type)
       end
     end
 

--- a/spec/heathen/processor_methods/tesseract_spec.rb
+++ b/spec/heathen/processor_methods/tesseract_spec.rb
@@ -20,7 +20,7 @@ describe Heathen::Processor do
     end
     it 'converts a tiff to HOCR' do
       processor.tesseract format: 'hocr'
-      expect(job.content.mime_type).to eq 'application/xml; charset=us-ascii'
+      expect(tesseract_hocr_mime_types).to include(job.content.mime_type)
     end
   end
 end

--- a/spec/helpers/mime_types.rb
+++ b/spec/helpers/mime_types.rb
@@ -1,9 +1,27 @@
+def ms_excel_mime_types
+  # LibreOffice 5.1 returns application/octet-stream
+  ['application/octet-stream; charset=binary',
+   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; charset=binary']
+end
+
 def ms_word_mime_types
   ['application/vnd.openxmlformats-officedocument.wordprocessingml.document; charset=binary',
    'application/zip; charset=binary']
 end
 
-def oo_mime_types
-  ['application/xml; charset=us-ascii',
-   'application/octet-stream; charset=binary']
+def oo_odp_mime_types
+  ['application/vnd.oasis.opendocument.presentation; charset=binary']
+end
+
+def oo_ods_mime_types
+  ['application/vnd.oasis.opendocument.spreadsheet; charset=binary']
+end
+
+def oo_odt_mime_types
+  ['application/vnd.oasis.opendocument.text; charset=binary']
+end
+
+def tesseract_hocr_mime_types
+  ['application/xml; charset=us-ascii', # tesseract v3
+   'text/xml; charset=us-ascii'] # tesseract v4
 end

--- a/spec/integration/standard_tasks_spec.rb
+++ b/spec/integration/standard_tasks_spec.rb
@@ -98,7 +98,7 @@ describe 'Standard Heathen tasks:' do
     it 'runs' do
       content = fixture('heathen/msword.docx').read
       new_content = converter.convert 'ooffice', content
-      expect(oo_mime_types).to include(new_content.mime_type)
+      expect(oo_odt_mime_types).to include(new_content.mime_type)
     end
   end
 


### PR DESCRIPTION
https://travis-ci.org/github/ifad/colore/builds/668025120

only mime type failures
```
Finished in 23.66 seconds (files took 0.81052 seconds to load)
138 examples, 4 failures
Failed examples:
rspec ./spec/heathen/processor_methods/libreoffice_spec.rb:60 # Heathen::Processor#libreoffice convert to MS from OO spreadsheet
rspec ./spec/heathen/processor_methods/libreoffice_spec.rb:73 # Heathen::Processor#libreoffice convert to OO from MS word
rspec ./spec/heathen/processor_methods/libreoffice_spec.rb:78 # Heathen::Processor#libreoffice convert to OO from MS spreadsheet
rspec ./spec/integration/standard_tasks_spec.rb:98 # Standard Heathen tasks: ooffice runs
```

Requires: #18 