### PR TITLE
Honor redis configuration in Sidekiq Workers

### DIFF
--- a/lib/sidekiq_workers.rb
+++ b/lib/sidekiq_workers.rb
@@ -6,6 +6,8 @@ require 'rest_client'
 require 'sidekiq'
 require 'sidekiq-cron'
 
+require_relative '../config/initializers/sidekiq.rb'
+
 module Colore
   module Sidekiq
     # This worker converts a document file to a new format and stores it.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,15 @@
+ENV['RACK_ENV'] = 'test'
+
 require 'pathname'
 require 'fileutils'
 require 'logger'
 require 'byebug'
 require 'rack/test'
+require 'sidekiq/testing'
 require 'simplecov'
 require 'timecop'
 
+Sidekiq.logger = nil
 SimpleCov.start
 
 SPEC_BASE = Pathname.new(__FILE__).realpath.parent
@@ -30,13 +34,8 @@ module RSpecMixin
   def app() described_class end
 end
 
-ENV['RACK_ENV'] = 'test'
-
 RSpec::configure do |rspec|
   rspec.tty = true
   rspec.color = true
   rspec.include RSpecMixin
 end
-
-require 'sidekiq/testing'
-Sidekiq.logger = nil


### PR DESCRIPTION
Initializer is required by `config.ru` and `sidekiq_app.rb`

The result is that when `sidekiq_workers` is required without the above
files (ex: `rspec`, or `bin/docpath`, it will use the default Redis
configuration url `localhost:6379`, without honoring `app.yml`'s value.

Without this change, `rspec` fails with the following error:

```
Finished in 0.00004 seconds (files took 1.15 seconds to load)
0 examples, 0 failures, 19 errors occurred outside of examples

`rescue in establish_connection': Error connecting to Redis on localhost:6379 (Errno::ECONNREFUSED) (Redis::CannotConnectError)
```