### PR TITLE
Expose file size in versions metadata

### DIFF
--- a/lib/document.rb
+++ b/lib/document.rb
@@ -214,6 +214,7 @@ module Colore
             content_type: content_type,
             filename: pfile.basename.to_s,
             path: file_path(v, pfile.basename),
+            size: pfile.size,
             author: author,
             created_at: pfile.mtime,
           }

--- a/spec/fixtures/document.json
+++ b/spec/fixtures/document.json
@@ -9,12 +9,14 @@
         "content_type": "application/zip; charset=binary",
         "filename": "arglebargle.docx",
         "path": "/document/app/12345/v001/arglebargle.docx",
+        "size": 12782,
         "author": "spliffy"
       },
       "txt": {
         "content_type": "text/plain; charset=us-ascii",
         "filename": "arglebargle.txt",
         "path": "/document/app/12345/v001/arglebargle.txt",
+        "size": 19,
         "author": "spliffy"
       }
     },
@@ -23,12 +25,14 @@
         "content_type": "application/zip; charset=binary",
         "filename": "arglebargle.docx",
         "path": "/document/app/12345/v002/arglebargle.docx",
+        "size": 12782,
         "author": "spliffy"
       },
       "txt": {
         "content_type": "text/plain; charset=us-ascii",
         "filename": "arglebargle.txt",
         "path": "/document/app/12345/v002/arglebargle.txt",
+        "size": 19,
         "author": "spliffy"
       }
     }


### PR DESCRIPTION
Size of the current document is already set in the `Content-Length` HTTP header when transferring a file

What about the existing metadata?

Close: #7
