### PR TITLE
Update Tika to 1.25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
 
 before_install:
   # tika
-  - TIKA_VERSION=1.24.1
+  - TIKA_VERSION=1.25
   - wget --quiet https://apache.osuosl.org/tika/tika-app-${TIKA_VERSION}.jar -O $HOME/bin/tika-app.jar
   - echo $'#!/bin/sh\n\nARGS="$@"\n\n[ $# -eq 0 ] && ARGS="--help"\n\nexec java -jar $HOME/bin/tika-app.jar $ARGS\n' > $HOME/bin/tika
   - cat $HOME/bin/tika


### PR DESCRIPTION
Version 1.24.1 is not available anymore on the apache server, causing
the Travis build to fail