### PR TITLE
Allow wkhtmltopdf meta params with multiple values

### DIFF
--- a/lib/heathen/processor_methods/wkhtmltopdf.rb
+++ b/lib/heathen/processor_methods/wkhtmltopdf.rb
@@ -28,7 +28,24 @@ module Heathen
         name  = meta.attributes['name'].value.sub(/^colore/, '-')
         value = if meta.attributes.key?('content')
           unless (v = meta.attributes['content'].value.strip).size.zero?
-            v
+            # Some wkhtmltopdf command line options such as `--custom-header KEY VALUE` allows for 2 values as params
+            # instead of the regular 1 param. In that case the meta content is splitted by `;` delimiter
+            # https://wkhtmltopdf.org/usage/wkhtmltopdf.txt
+            #
+            # Ex:
+            # Let's say we have a report in HTML that needs to be converted into PDF and the report contains some images that
+            # are not publicly served but they need credentials. We can let wkhtml2pdf know it needs to send authentication
+            # credentials via custom HTML meta headers like
+            #
+            # <meta name="colore-custom-header" content="X-AUTH-TOKEN;FooBarBaz" />
+            # <meta name="colore-custom-header-propagation" />
+            #
+            # that will arrive to colore as:
+            # meta.attributes['content'].value = "X-AUTH-TOKEN;FooBarBaz"
+            #
+            # and here we are splitting it in 2 keywords so the Executioner will escape them indidually as if we pass them
+            # sepparated by ' ' Open3 will send them to wkhtml2pdf as 2 single param enclosed in '""' which will basically be ignored
+            v.split ';'
           end
         end
 


### PR DESCRIPTION
Some wkhtmltopdf command line options such as
`--custom-header KEY VALUE` allows for 2 values as params instead of the
regular 1 param. In that case the meta content is splitted by `;`
delimiter https://wkhtmltopdf.org/usage/wkhtmltopdf.txt

Ex:
Let's say we have a report in HTML that needs to be converted into PDF
and the report contains some images that are not publicly served but
they need credentials. We can let wkhtml2pdf know it needs to send
authentication credentials via custom HTML meta headers like

```html
<meta name="colore-custom-header" content="X-AUTH-TOKEN;FooBarBaz" />
<meta name="colore-custom-header-propagation" />
```

that will arrive to colore as:

```rb
meta.attributes['content'].value = "X-AUTH-TOKEN;FooBarBaz"
```

and here we are splitting it in 2 keywords so the Executioner will
escape them indidually as if we pass them sepparated by ' ' Open3 will
send them to wkhtml2pdf as 2 single param enclosed in '""' which will
basically be ignored