### PR TITLE
Replace `+matte` with `-alpha off`

### DIFF
--- a/lib/heathen/task.rb
+++ b/lib/heathen/task.rb
@@ -54,13 +54,13 @@ module Heathen
 end
 
 Heathen::Task.register 'ocr', 'image/.*' do
-  convert_image to: :tiff, params: '-depth 8 -density 300 -background white +matte'
+  convert_image to: :tiff, params: '-depth 8 -density 300 -background white -alpha off'
   job.reset_content_file!
   tesseract format: 'pdf'
 end
 
 Heathen::Task.register 'ocr_text', 'image/.*' do
-  convert_image to: :tiff, params: '-depth 8 -density 300 -background white +matte'
+  convert_image to: :tiff, params: '-depth 8 -density 300 -background white -alpha off'
   job.reset_content_file!
   tesseract format: nil
 end


### PR DESCRIPTION
`+matte` is not available anymore in `v7`, being replaced by `-alpha off`. `-alpha off` is available since 2012

md5 checksum has been manually tested

Refs:
- ImageMagick/ImageMagick6@ce3516c
- ImageMagick/ImageMagick#1974