### PR TITLE
Fix ImageMagick command for v7 option handling

### DIFF
--- a/lib/heathen/processor_methods/convert_image.rb
+++ b/lib/heathen/processor_methods/convert_image.rb
@@ -4,14 +4,14 @@ module Heathen
     # utility from ImageMagick. Sets the job content to the new format.
     # @param to [String] the format to convert to (suffix)
     # @param params [Array] optional parameters to pass to the convert program.
-    def convert_image to: 'tiff', params: nil
+    def convert_image to: 'tiff', params: ''
       expect_mime_type 'image/*'
 
       target_file = temp_file_name '', ".#{to.to_s}"
       executioner.execute(
         *[Colore::C_.convert_path,
-        params.split(/ +/),
         job.content_file,
+        params.split(/ +/),
         target_file].flatten
       )
       raise ConversionFailed.new if executioner.last_exit_status != 0


### PR DESCRIPTION
Options specified before the input image can be interpreted as options to generate an image.

Example:

```
convert -size 300x200 xc:lightblue image.png
```

The `-size` and `xc:lightblue` options create a new image, and `image.png` is considered the output file. 

By moving the options **after** the input image, we ensure that the input file is interpreted correctly and only the output is modified according to the specified options.

This will also add compatibility to ImageMagick v7