### PR TITLE
Move tempfile reset logic to a dedicated method

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -469,13 +469,6 @@ Style/RescueModifier:
     - 'lib/document.rb'
     - 'lib/heathen/filename.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: ConvertCodeThatCanStartToReturnNil, AllowedMethods, MaxChainLength.
-# AllowedMethods: present?, blank?, presence, try, try!
-Style/SafeNavigation:
-  Exclude:
-    - 'lib/heathen/job.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowAsExpressionSeparator.
 Style/Semicolon:


### PR DESCRIPTION
This change extracts the tempfile cleanup logic into a separate method `reset_content_file!`. This improves code readability and  reusability by eliminating duplicated logic in the `content=` and `content_file` methods. Additionally, it ensures that tempfiles are properly unlinked to avoid file leakage when resetting content.

Close #264