### PR TITLE
Fix Style/FileWrite offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -312,13 +312,6 @@ Style/FetchEnvVar:
     - 'lib/heathen/processor_methods/libreoffice.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
-Style/FileWrite:
-  Exclude:
-    - 'bin/cvheathen'
-    - 'lib/document.rb'
-    - 'lib/legacy_converter.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: format, sprintf, percent
 Style/FormatString:
@@ -518,7 +511,6 @@ Style/StringConcatenation:
     - 'lib/heathen.rb'
     - 'lib/heathen/processor.rb'
     - 'lib/sidekiq_app.rb'
-    - 'spec/lib/document_spec.rb'
     - 'spec/lib/sidekiq_workers_spec.rb'
     - 'unicorn.rb'
 

--- a/bin/cvheathen
+++ b/bin/cvheathen
@@ -39,7 +39,7 @@ files = []
 if in_file.file?
   abort "Output is a directory, but expected a file" if out_file.directory?
   content = converter.convert action, File.read(in_file), language
-  File.open(out_file, 'wb') { |f| f.write content }
+  File.binwrite(out_file, content)
 elsif in_file.directory?
   abort "Invalid output directory" unless out_file.directory?
   Dir.glob(in_file + (recurse ? '**/*' : '*')).each do |file|
@@ -49,7 +49,7 @@ elsif in_file.directory?
       content = converter.convert action, File.read(file), language
       new_file = Heathen::Filename.suggest_in_new_dir file, content.mime_type, in_file.to_s, out_file.to_s
       Pathname.new(new_file).parent.mkpath
-      File.open(new_file, 'wb') { |f| f.write content }
+      File.binwrite(new_file, content)
     rescue StandardError => e
       logger.error "Failed to convert #{file}: #{e.message}"
     end

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -145,7 +145,7 @@ module Colore
 
       body = StringIO.new(body) unless body.respond_to?(:read) # string -> IO
       File.open(directory + version + filename, "wb") { |f| IO.copy_stream(body, f) }
-      File.open(directory + version + AUTHOR_FILE, 'w') { |f| f.write author }
+      File.write(directory + version + AUTHOR_FILE, author)
     end
 
     # Sets the specified version as current.

--- a/lib/legacy_converter.rb
+++ b/lib/legacy_converter.rb
@@ -35,7 +35,7 @@ module Colore
 
     # Stores the specified file in the legacy directory
     def store_file(filename, content)
-      File.open(@legacy_dir + filename, 'wb') { |f| f.write content }
+      File.binwrite(@legacy_dir + filename, content)
     end
 
     # Loads and returns a legacy converted file


### PR DESCRIPTION
Also refactor document spec by using `join` instead of `+` because it's shorter, clearer, and uses less memory, even if it is slightly less performant in terms of IPS

Ref: #276