### PR TITLE
Fix warning related to content_tempfile

### DIFF
--- a/lib/heathen/job.rb
+++ b/lib/heathen/job.rb
@@ -34,7 +34,6 @@ module Heathen
       @original_mime_type = content.mime_type
       self.content = @original_content
       @sandbox_dir = sandbox_dir
-      @content_tempfile = nil
     end
 
     # Sets the current content to the supplied [String]. Will also
@@ -50,22 +49,26 @@ module Heathen
     # method is called, for a given step, a temporary file is created and the content is
     # written to it. This will persist until the content is changed.
     def content_file(suffix = '')
-      return @content_tempfile.path if @content_tempfile
+      return content_tempfile.path if content_tempfile
 
       @content_tempfile = Tempfile.new ["heathen", suffix], @sandbox_dir
-      @content_tempfile.binmode
-      @content_tempfile.write @content
-      @content_tempfile.close
+      content_tempfile.binmode
+      content_tempfile.write content
+      content_tempfile.close
 
-      @content_tempfile.path
+      content_tempfile.path
     end
 
     # Call this to reset the tempfile between multisteps tasks
     def reset_content_file!
-      return if @content_tempfile.nil?
+      return if content_tempfile.nil?
 
-      @content_tempfile.unlink
+      content_tempfile.unlink
       @content_tempfile = nil
     end
+
+    private
+
+    attr_reader :content_tempfile
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -109,8 +109,7 @@ RSpec.configure do |config|
 
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.
-  # TODO: enable this
-  config.warnings = false
+  config.warnings = true
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an


### PR DESCRIPTION
This commit improves the `Heathen::Job` class by implementing lazy 
initialization for the `@content_tempfile` instance variable.

The changes:
1. Remove explicit `nil` initialization in the constructor
2. Introduce a private `attr_reader` for `content_tempfile`
3. Replace direct `@content_tempfile` access with the new reader method

These modifications address the following issues:
- Eliminate uninitialized instance variable warning
- Improve encapsulation by making `content_tempfile` private
- Enhance code clarity and maintainability

The behavior of the class remains unchanged, ensuring backwards 
compatibility while improving its internal structure.