### PR TITLE
Replace deprecated URI.escape

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -86,10 +86,6 @@ Lint/UnusedMethodArgument:
   Exclude:
     - 'lib/document.rb'
 
-Lint/UriEscapeUnescape:
-  Exclude:
-    - 'spec/lib/app_spec.rb'
-
 Lint/UselessAssignment:
   Exclude:
     - 'bin/cvheathen'

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Colore::App do
   describe 'POST update title' do
     it 'runs' do
       title = "This is a new document"
-      post "/document/#{appname}/#{doc_id}/title/#{URI.escape(title)}"
+      post "/document/#{appname}/#{doc_id}/title/#{URI.encode_www_form_component(title)}"
       expect(last_response.status).to eq 200
       expect(last_response.content_type).to eq 'application/json'
       expect(JSON.parse(last_response.body)).to be_a Hash
@@ -111,7 +111,7 @@ RSpec.describe Colore::App do
 
     it 'fails if the document does not exist' do
       title = "This is a new document"
-      post "/document/#{appname}/foobar/title/#{URI.escape(title)}"
+      post "/document/#{appname}/foobar/title/#{URI.encode_www_form_component(title)}"
       expect(last_response.status).to eq 404
       expect(last_response.content_type).to eq 'application/json'
       expect(JSON.parse(last_response.body)).to be_a Hash


### PR DESCRIPTION
This commit updates the specs to use `URI.encode_www_form_component` instead of the deprecated `URI.escape` method.

- Replace `URI.escape` with `URI.encode_www_form_component`
- Maintain existing test behavior and expectations
- Ensure proper URL encoding for document titles in test requests

This update removes usage of a deprecated method, improving the codebase's compatibility with newer Ruby versions while maintaining the original functionality of the tests.