### PR TITLE
Prefer require_relative over path injection

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -41,8 +41,6 @@ Lint/AmbiguousOperatorPrecedence:
     - 'bin/autoheathen'
     - 'bin/cvheathen'
     - 'bin/docpath'
-    - 'config.ru'
-    - 'lib/sidekiq_app.rb'
 
 # Configuration parameters: AllowComments, AllowEmptyLambdas.
 Lint/EmptyBlock:
@@ -53,11 +51,6 @@ Lint/EmptyBlock:
 Lint/NonAtomicFileOperation:
   Exclude:
     - 'lib/document.rb'
-
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Lint/NonDeterministicRequireOrder:
-  Exclude:
-    - 'lib/heathen.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 Lint/ParenthesesAsGroupedExpression:
@@ -383,12 +376,9 @@ Style/StringConcatenation:
     - 'bin/autoheathen'
     - 'bin/cvheathen'
     - 'bin/docpath'
-    - 'config.ru'
     - 'lib/config.rb'
     - 'lib/document.rb'
-    - 'lib/heathen.rb'
     - 'lib/heathen/processor.rb'
-    - 'lib/sidekiq_app.rb'
     - 'unicorn.rb'
 
 # This cop supports safe autocorrection (--autocorrect).

--- a/config.ru
+++ b/config.ru
@@ -4,15 +4,10 @@
 #
 # Rackup config for the Colore app
 #
-require 'pathname'
 require "sinatra"
 
-BASE = Pathname.new(__FILE__).realpath.parent
-$: << BASE
-$: << BASE + 'lib'
-require 'config/initializers/sidekiq'
-
-require 'app'
+require_relative 'config/initializers/sidekiq'
+require_relative 'lib/app'
 
 require 'sidekiq/web'
 require 'sidekiq/cron/web'

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'pathname'
 require 'sidekiq'
-require 'config'
+
+require_relative '../../lib/config'
 
 Sidekiq.configure_server do |config|
   config.redis = Colore::C_.redis

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-require 'pathname'
 require 'haml'
 require 'net/http'
-require 'sinatra/base'
+require 'pathname'
 require 'pp'
+require 'sinatra/base'
+
 require_relative 'colore'
 
 module Colore

--- a/lib/autoheathen.rb
+++ b/lib/autoheathen.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
-require 'heathen'
+require_relative 'heathen'
+
 require_relative 'autoheathen/config'
 require_relative 'autoheathen/email_processor'

--- a/lib/autoheathen/email_processor.rb
+++ b/lib/autoheathen/email_processor.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
-require 'mail'
-require 'yaml'
-require 'logger'
-require 'haml'
 require 'filemagic/ext'
-require_relative 'config'
-require 'heathen'
+require 'haml'
+require 'logger'
+require 'mail'
+require 'pathname'
+require 'yaml'
 
 module AutoHeathen
   class EmailProcessor

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'erb'
+require 'pathname'
 require 'yaml'
 
 Encoding.default_internal = 'UTF-8'

--- a/lib/converter.rb
+++ b/lib/converter.rb
@@ -2,7 +2,8 @@
 
 require 'filemagic/ext'
 require 'mime/types'
-require 'heathen'
+
+require_relative 'heathen'
 
 module Colore
   # The Colore Converter is a glue class to allow Colore to access the Heathen conversion

--- a/lib/doc_key.rb
+++ b/lib/doc_key.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'digest/md5'
+require 'pathname'
 
 module Colore
   # This is the unique identifier for a document, a composite of

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'filemagic/ext'
+require 'fileutils'
+require 'json'
 require 'pathname'
 require 'stringio'
-require 'json'
-require 'filemagic/ext'
+
 require_relative 'doc_key'
 
 module Colore

--- a/lib/heathen.rb
+++ b/lib/heathen.rb
@@ -2,7 +2,6 @@
 
 require 'filemagic/ext'
 require 'pathname'
-HEATHEN_BASE = Pathname.new(__FILE__).realpath.parent + 'heathen'
 
 require_relative 'heathen/errors'
 require_relative 'heathen/filename'
@@ -11,6 +10,10 @@ require_relative 'heathen/task'
 require_relative 'heathen/converter'
 require_relative 'heathen/executioner'
 require_relative 'heathen/processor'
-Dir.glob((HEATHEN_BASE + 'processor_methods' + '*.rb').to_s).each do |method|
-  require_relative method
-end
+
+require_relative 'heathen/processor_methods/convert_image'
+require_relative 'heathen/processor_methods/htmltotext'
+require_relative 'heathen/processor_methods/libreoffice'
+require_relative 'heathen/processor_methods/pdftotext'
+require_relative 'heathen/processor_methods/tesseract'
+require_relative 'heathen/processor_methods/wkhtmltopdf'

--- a/lib/heathen/processor.rb
+++ b/lib/heathen/processor.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
+require 'fileutils'
 require 'logger'
+require 'pathname'
 
 module Heathen
   # The Processor is the heart of the Heathen conversion process. Mixed in to it are all

--- a/lib/heathen/processor_methods/libreoffice.rb
+++ b/lib/heathen/processor_methods/libreoffice.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 module Heathen
   class Processor
     DEV_SHM_PATH = '/dev/shm'

--- a/lib/legacy_converter.rb
+++ b/lib/legacy_converter.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-require 'pathname'
+require 'digest/sha2'
 require 'filemagic/ext'
 require 'mime/types'
-require 'heathen'
-require 'digest/sha2'
+require 'pathname'
+
+require_relative 'heathen'
 
 module Colore
   # The Colore Legacy Converter provides the conversion functionality from

--- a/lib/sidekiq_app.rb
+++ b/lib/sidekiq_app.rb
@@ -1,16 +1,5 @@
 # frozen_string_literal: true
 
-#
 # Application initializer for the Colore Sidekiq process. See (BASE/run_sidekiq) for usage.
-#
-#
-require 'pathname'
-require 'sidekiq'
-
-BASE = Pathname.new(__FILE__).realpath.parent.parent
-$: << BASE # for config initializers
-$: << BASE + 'lib'
-
-require 'config/initializers/sidekiq'
-
+require_relative '../config/initializers/sidekiq'
 require_relative 'colore'

--- a/spec/helpers/storage.rb
+++ b/spec/helpers/storage.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'fileutils'
+require 'pathname'
 
 def tmp_storage_dir
   Pathname.new('/tmp') + "colore_test.#{Process.pid}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require 'rspec'
 
 require 'byebug'
 require 'logger'
+require 'pathname'
 require 'rack/test'
 require 'sidekiq/testing'
 require 'simplecov'


### PR DESCRIPTION
`require_relative` is preferred over `require` for files within the same project because it uses paths relative to the current file, making code more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for consistency, performance, and improved portability.