### PR TITLE
Improve paths

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -376,7 +376,6 @@ Style/StringConcatenation:
     - 'bin/autoheathen'
     - 'bin/cvheathen'
     - 'bin/docpath'
-    - 'lib/config.rb'
     - 'lib/document.rb'
     - 'lib/heathen/processor.rb'
     - 'unicorn.rb'

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -45,13 +45,12 @@ module Colore
     attr_accessor :wkhtmltopdf_params
 
     def self.config_file_path
-      # BASE/config/app.yml
-      Pathname.new(__FILE__).realpath.parent.parent + 'config' + 'app.yml'
+      Pathname.new File.expand_path('../config/app.yml', __dir__)
     end
 
     def self.config
       @config ||= begin
-        template = ERB.new(File.read(config_file_path))
+        template = ERB.new(config_file_path.read)
         yaml = YAML.load(template.result)
         c = new
         c.storage_directory = yaml['storage_directory']

--- a/lib/legacy_converter.rb
+++ b/lib/legacy_converter.rb
@@ -20,8 +20,8 @@ module Colore
 
     def initialize(storage_dir = C_.storage_directory)
       @storage_dir = Pathname.new(storage_dir)
-      @legacy_dir = @storage_dir + LEGACY
-      @legacy_dir.mkpath
+      @legacy_dir = @storage_dir.join(LEGACY)
+      legacy_dir.mkpath
     end
 
     # Converts the given file and stores it in the legacy directory
@@ -33,19 +33,20 @@ module Colore
       content = Heathen::Converter.new.convert(action, orig_content, language)
       filename = Digest::SHA2.hexdigest content
       store_file filename, content
-      (@legacy_dir.basename + filename).to_s
+      legacy_dir.basename.join(filename).to_s
     end
 
     # Stores the specified file in the legacy directory
     def store_file(filename, content)
-      File.binwrite(@legacy_dir + filename, content)
+      File.binwrite(legacy_dir.join(filename), content)
     end
 
     # Loads and returns a legacy converted file
     def get_file(filename)
-      raise "File does not exists" unless (@legacy_dir + filename).file?
+      file_path = legacy_dir.join(filename)
+      raise "File does not exists" unless file_path.file?
 
-      File.read(@legacy_dir + filename)
+      file_path.read
     end
   end
 end

--- a/spec/lib/colore/sidekiq/legacy_purge_worker_spec.rb
+++ b/spec/lib/colore/sidekiq/legacy_purge_worker_spec.rb
@@ -21,16 +21,16 @@ RSpec.describe Colore::Sidekiq::LegacyPurgeWorker do
       file1.write('foobar')
       file2.write('foobar')
       described_class.new.perform
-      expect(file1.file?).to be true
-      expect(file2.file?).to be true
+      expect(file1).to be_file
+      expect(file2).to be_file
       Timecop.freeze(Date.today + 1)
       described_class.new.perform
-      expect(file1.file?).to be true
-      expect(file2.file?).to be true
+      expect(file1).to be_file
+      expect(file2).to be_file
       Timecop.freeze(Date.today + 3)
       described_class.new.perform
-      expect(file1.file?).to be false
-      expect(file2.file?).to be false
+      expect(file1).not_to be_file
+      expect(file2).not_to be_file
     end
   end
 end

--- a/spec/lib/legacy_converter_spec.rb
+++ b/spec/lib/legacy_converter_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Colore::LegacyConverter do
     it 'runs' do
       new_filename = converter.convert_file new_format, content
       expect(new_filename).not_to be_nil
-      expect((storage_dir + new_filename).file?).to be true
-      stored_content = File.read(storage_dir + new_filename)
+      expect(storage_dir.join(new_filename)).to be_file
+      stored_content = storage_dir.join(new_filename).read
       expect(stored_content).to eq 'The quick brown fox'
     end
   end
@@ -34,8 +34,8 @@ RSpec.describe Colore::LegacyConverter do
       filename = 'foo.txt'
       content = 'The quick brown fox'
       converter.store_file filename, content
-      expect((converter.legacy_dir + filename).file?).to be true
-      expect(File.read(converter.legacy_dir + filename)).to eq content
+      expect(converter.legacy_dir.join(filename)).to be_file
+      expect(converter.legacy_dir.join(filename).read).to eq content
     end
   end
 


### PR DESCRIPTION
- Use `.read` on pathnames
- Use `join` for clarity
- Use `be predicate` in specs

```
Comparison (IPS):
       pathname.read:    92400.5 i/s
 File.read(pathname):    90753.4 i/s - same-ish: difference falls within error

Comparison (Memory):
       pathname.read:       1395 allocated
 File.read(pathname):       1435 allocated - 1.03x more
```