### PR TITLE
Fix language alpha3 util

### DIFF
--- a/lib/heathen/processor_methods/tesseract.rb
+++ b/lib/heathen/processor_methods/tesseract.rb
@@ -12,15 +12,15 @@ module Heathen
       expect_mime_type 'image/tiff'
 
       # Lookup the ISO 639-2 (alpha-3) language object required by Tesseract
-      lang_alpha3 = Colore::Utils.lang_alpha3(job.language)
-      raise InvalidLanguageInStep.new(job.language) if lang_alpha3.nil?
+      language_alpha3 = Colore::Utils.language_alpha3(job.language)
+      raise InvalidLanguageInStep.new(job.language) if language_alpha3.nil?
 
       target_file = temp_file_name
       executioner.execute(
         Colore::C_.tesseract_path,
         job.content_file,
         target_file,
-        '-l', lang_alpha3,
+        '-l', language_alpha3,
         format
       )
       raise ConversionFailed.new(executioner.last_messages) if executioner.last_exit_status != 0

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -18,12 +18,12 @@ module Colore
       end
     end
 
-    # Converts an ISO 639-1 (alpha-2) language code to its corresponding ISO 639-2 (alpha-3) code.
+    # Converts a language code to its corresponding ISO 639-2 (alpha-3) code.
     #
-    # @param [String] lang_alpha2 The ISO 639-1 (alpha-2) language code.
-    # @return [String] The ISO 639-2 (alpha-3) language code, or `nil` if the alpha-2 code is not found.
-    def self.lang_alpha3(lang_alpha2)
-      ISO_639.find(lang_alpha2)&.alpha3
+    # @param [String] language The ISO 639-1 (alpha-2) or ISO 639-2 (alpha-3) language code.
+    # @return [String] The ISO 639-2 (alpha-3) language code, or `nil` if the code is not found.
+    def self.language_alpha3(language)
+      ISO_639.find(language)&.alpha3
     end
   end
 end

--- a/spec/lib/utils_spec.rb
+++ b/spec/lib/utils_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe Colore::Utils do
     end
   end
 
-  describe '.lang_alpha3' do
-    subject { described_class.lang_alpha3(language) }
+  describe '.language_alpha3' do
+    subject { described_class.language_alpha3(language) }
 
     let(:language) { 'en' }
 


### PR DESCRIPTION
The documentation was misleading. Also rename to `language_alpha3` for uniformity