### PR TITLE
Use `Pathname#write` where possible

### DIFF
--- a/lib/document.rb
+++ b/lib/document.rb
@@ -90,16 +90,17 @@ module Colore
 
     # @return the document title.
     def title
-      return '' unless File.exist?(directory + 'title')
+      title_file = directory.join('title')
+      return '' unless title_file.file?
 
-      File.read(directory + 'title').chomp
+      title_file.read.chomp
     end
 
     # Sets the document title.
     def title=(new_title)
       return if new_title.to_s.empty?
 
-      File.open(directory + 'title', 'w') { |f| f.puts new_title }
+      directory.join('title').write new_title
     end
 
     # Returns an array of the document version identifiers.
@@ -149,7 +150,7 @@ module Colore
 
       body = StringIO.new(body) unless body.respond_to?(:read) # string -> IO
       File.open(directory + version + filename, "wb") { |f| IO.copy_stream(body, f) }
-      File.write(directory + version + AUTHOR_FILE, author)
+      directory.join(version, AUTHOR_FILE).write author
     end
 
     # Sets the specified version as current.
@@ -233,9 +234,7 @@ module Colore
     # This metadata is just the {#to_hash}, as JSON, and is intended for access by client
     # applications. It is not used by Colore for anything.
     def save_metadata
-      File.open(directory + 'metadata.json', "w") do |f|
-        f.puts JSON.pretty_generate(to_hash)
-      end
+      directory.join('metadata.json').write JSON.pretty_generate(to_hash)
     end
   end
 end

--- a/lib/tika_config.rb
+++ b/lib/tika_config.rb
@@ -39,7 +39,7 @@ module Colore
         return file if file.file?
 
         FileUtils.mkdir_p(tika_config_path.join('ocr', VERSION))
-        File.write(file, format(TEMPLATE, language_alpha3: language_alpha3))
+        file.write format(TEMPLATE, language_alpha3: language_alpha3)
         file
       end
     end

--- a/spec/lib/tika_config_spec.rb
+++ b/spec/lib/tika_config_spec.rb
@@ -45,14 +45,14 @@ RSpec.describe Colore::TikaConfig do
       let(:language) { 'en' }
 
       before do
-        allow(File).to receive(:write)
-          .with(tika_test_config_path.join('ocr', described_class::VERSION, 'tika.eng.xml'), an_instance_of(String))
+        allow(FileUtils).to receive(:mkdir_p)
+          .with(tika_test_config_path.join('ocr', described_class::VERSION))
           .and_call_original
       end
 
       it 'does not overwrite it' do
         2.times { described_class.path_for(language) }
-        expect(File).to have_received(:write).once
+        expect(FileUtils).to have_received(:mkdir_p).once
       end
     end
   end


### PR DESCRIPTION
Also refactor title to use `Pathname#read` instead of using the global
`File.read`
