### PR TITLE
Use atomic file operation to unlink file

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,11 +47,6 @@ Lint/EmptyBlock:
   Exclude:
     - 'lib/heathen/processor.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Lint/NonAtomicFileOperation:
-  Exclude:
-    - 'lib/document.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 Lint/ParenthesesAsGroupedExpression:
   Exclude:

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -159,7 +159,7 @@ module Colore
       raise InvalidVersion.new unless /^v\d+$/.match?(version)
 
       # need to do this, or ln_s will put the symlink *into* the old dir
-      File.unlink directory + CURRENT if File.exist? directory + CURRENT
+      FileUtils.rm_f directory + CURRENT
       FileUtils.ln_s version, directory + CURRENT, force: true
     end
 


### PR DESCRIPTION
Fix `Lint/NonAtomicFileOperation` unsafe offense

`FileUtils.rm_f` is an alias of `FileUtils.safe_unlink`